### PR TITLE
Add Python 3.7 compatibility

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,3 @@
 -r requirements.txt
 flake8==2.5.1
-ipython==4.0.1
-pdbpp==0.8.3
 pytest==2.8.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 parsimonious==0.6.2
-toolz==0.7.4
+toolz==0.9.0
 future==0.16.0


### PR DESCRIPTION
Needed to update toolz for 3.7 compatibility.

Also removed `ipython` and `pdbpp` from the dev-requirements, they're not actually requirements at all, and their pinned versions were for 2.7 anyway.