### PR TITLE
fix regex deprecation warning

### DIFF
--- a/pyseeyou/grammar.py
+++ b/pyseeyou/grammar.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from parsimonious.grammar import Grammar
 
-ICUMessageFormat = Grammar('''
+ICUMessageFormat = Grammar(r'''
     message_format_pattern =
         (message_format_element/octothorpe/string)*
 
@@ -25,10 +25,10 @@ ICUMessageFormat = Grammar('''
     offset = _ "offset" _ ":" _ digits _
 
     octothorpe   = ~"#"
-    string       = (~"\w+"/~"[^{}]+"/_)+
-    id           = ~"\w+"i
-    replace_type = ~"\w+"i
-    decimal      = ~"[0-9]+(\.[0-9]+)?"
+    string       = (~"\\w+"/~"[^{}]+"/_)+
+    id           = ~"\\w+"i
+    replace_type = ~"\\w+"i
+    decimal      = ~"[0-9]+(\\.[0-9]+)?"
     digits       = ~"[0-9]+"
-    _            = ~"\s*"
+    _            = ~"\\s*"
     ''')


### PR DESCRIPTION
Hi! I was seeing this warning https://github.com/rolepoint/pyseeyou/issues/8 so I thought I'd try and fix it. I made this change and ran pytest locally for python 2.7 and 3.9 and the tests pass so I think this change is safe? Thanks!